### PR TITLE
Sort job list by time

### DIFF
--- a/webapp/jobs/newendpoints.go
+++ b/webapp/jobs/newendpoints.go
@@ -8,16 +8,18 @@ import (
 )
 
 type JobsEndpoints struct {
-	GetHandler    GetJobHandler
-	CreateHandler CreateJobHandler
-	ListHandler   ListJobHandler
+	GetHandler     GetJobHandler
+	CreateHandler  CreateJobHandler
+	ListHandler    ListJobHandler
+	ReindexHandler ReindexHandler
 }
 
 func NewJobsEndpoints(redisClient *redis.Client, k8client *kubernetes.Clientset, jobTemplateMgr *models.JobTemplateManager) JobsEndpoints {
 	return JobsEndpoints{
-		GetHandler:    GetJobHandler{redisClient},
-		CreateHandler: CreateJobHandler{redisClient, k8client, jobTemplateMgr},
-		ListHandler:   ListJobHandler{redisClient},
+		GetHandler:     GetJobHandler{redisClient},
+		CreateHandler:  CreateJobHandler{redisClient, k8client, jobTemplateMgr},
+		ListHandler:    ListJobHandler{redisClient},
+		ReindexHandler: ReindexHandler{redisClient},
 	}
 }
 
@@ -25,4 +27,5 @@ func (e JobsEndpoints) WireUp(baseUrlPath string) {
 	http.Handle(baseUrlPath+"/get", e.GetHandler)
 	http.Handle(baseUrlPath+"/new", e.CreateHandler)
 	http.Handle(baseUrlPath+"", e.ListHandler)
+	http.Handle(baseUrlPath+"/reindex", e.ReindexHandler)
 }

--- a/webapp/jobs/reindexhandler.go
+++ b/webapp/jobs/reindexhandler.go
@@ -1,0 +1,34 @@
+package jobs
+
+import (
+	"github.com/go-redis/redis/v7"
+	"github.com/guardian/mediaflipper/webapp/helpers"
+	"github.com/guardian/mediaflipper/webapp/models"
+	"log"
+	"net/http"
+)
+
+type ReindexHandler struct {
+	redisClient *redis.Client
+}
+
+func (h ReindexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !helpers.AssertHttpMethod(r, w, "PUT") {
+		return
+	}
+
+	err := models.ReIndexJobContainers(h.redisClient)
+	if err != nil {
+		log.Printf("Reindex operation failed!")
+		helpers.WriteJsonContent(helpers.GenericErrorResponse{
+			Status: "db_error",
+			Detail: err.Error(),
+		}, w, 500)
+	} else {
+		helpers.WriteJsonContent(helpers.GenericErrorResponse{
+			Status: "ok",
+			Detail: "reindex completed",
+		}, w, 200)
+	}
+
+}


### PR DESCRIPTION
adding secondary index to the datastore for jobs to sort by creation time. Updating jobs-list endpoint to return in ctime order by default.