### PR TITLE
Fix items getting left on running queue and associated server crash/502

### DIFF
--- a/common/models/jobcontainer.go
+++ b/common/models/jobcontainer.go
@@ -110,7 +110,11 @@ func (c *JobContainer) FailCurrentStep(msg string) {
 	nowTime := time.Now()
 	c.EndTime = &nowTime
 	c.ErrorMessage = msg
-	c.Steps[c.CompletedSteps] = c.Steps[c.CompletedSteps].WithNewStatus(JOB_FAILED, &msg)
+	if c.CompletedSteps >= len(c.Steps) {
+		log.Printf("ERROR: Trying to fail current step when all steps have already been processed? Offending data was %s", spew.Sdump(c))
+	} else {
+		c.Steps[c.CompletedSteps] = c.Steps[c.CompletedSteps].WithNewStatus(JOB_FAILED, &msg)
+	}
 }
 
 /**

--- a/common/models/jobqueue.go
+++ b/common/models/jobqueue.go
@@ -161,7 +161,9 @@ func ReleaseQueueLock(client *redis.Client, queueName QueueName) {
 
 /*
 block until the given queue lock is available or the timeout occurs
+commented out as nothing is using it at the moment
 */
+/*
 func WaitForQueueLock(client *redis.Client, queueName QueueName, timeout time.Duration) error {
 	timeoutTimer := time.NewTicker(timeout)
 	clearedChannel := make(chan error)
@@ -188,6 +190,7 @@ func WaitForQueueLock(client *redis.Client, queueName QueueName, timeout time.Du
 		return checkErr
 	}
 }
+*/
 
 type QueueLockCallback func(error)
 

--- a/common/models/jobqueue.go
+++ b/common/models/jobqueue.go
@@ -1,0 +1,224 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"github.com/go-redis/redis/v7"
+	"github.com/google/uuid"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type QueueName string
+
+const (
+	REQUEST_QUEUE QueueName = "jobrequestqueue"
+	RUNNING_QUEUE QueueName = "jobrunningqueue"
+)
+
+/** -----------------
+queue entry data
+----------------
+*/
+type JobQueueEntry struct {
+	JobId  uuid.UUID
+	StepId uuid.UUID
+	Status JobStatus
+}
+
+func (j JobQueueEntry) Marshal() string {
+	return j.JobId.String() + "|" + j.StepId.String() + "|" + strconv.FormatInt(int64(j.Status), 10)
+}
+
+func UnmarshalJobQueueEntry(from string) (JobQueueEntry, error) {
+	parts := strings.Split(from, "|")
+	if len(parts) != 3 {
+		return JobQueueEntry{}, errors.New("incorrect data, did not have 3 sections")
+	}
+	jobId, jobIdErr := uuid.Parse(parts[0])
+	if jobIdErr != nil {
+		return JobQueueEntry{}, jobIdErr
+	}
+	stepId, stepIdErr := uuid.Parse(parts[1])
+	if stepIdErr != nil {
+		return JobQueueEntry{}, stepIdErr
+	}
+	jobStatus, statusErr := strconv.ParseInt(parts[2], 10, 8)
+	if statusErr != nil {
+		return JobQueueEntry{}, statusErr
+	}
+
+	return JobQueueEntry{
+		JobId:  jobId,
+		StepId: stepId,
+		Status: JobStatus(jobStatus),
+	}, nil
+}
+
+/** -----------------
+queue manipulation
+----------------
+*/
+func GetQueueLength(client redis.Cmdable, queueName QueueName) (int64, error) {
+	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
+	result := client.LLen(jobKey)
+
+	count, err := result.Result()
+	if err != nil {
+		log.Printf("Could not retrieve queue length for %s: %s", queueName, err)
+	}
+	return count, err
+}
+
+/**
+get a 'snapshot' of the queue state at this moment in time.
+it is recommended to acquire the queue lock first and not release it until done,
+so that the snapshot
+*/
+func SnapshotQueue(client redis.Cmdable, queueName QueueName) ([]JobQueueEntry, error) {
+	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
+
+	rawData, err := client.LRange(jobKey, 0, -1).Result()
+
+	if err != nil {
+		log.Printf("Could not range %s: %s", jobKey, err)
+		return nil, err
+	}
+
+	result := make([]JobQueueEntry, len(rawData))
+	for i, rawEntry := range rawData {
+		ent, parseErr := UnmarshalJobQueueEntry(rawEntry)
+		if parseErr != nil {
+			log.Printf("ERROR: Bad data in the %s queue: %s. Offending data was %s.", jobKey, parseErr, rawEntry)
+			return nil, parseErr
+		}
+		result[i] = ent
+	}
+	return result, nil
+}
+
+func RemoveFromQueue(client redis.Cmdable, queueName QueueName, entry JobQueueEntry) error {
+	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
+	removed, err := client.LRem(jobKey, 0, entry.Marshal()).Result()
+	if err != nil {
+		log.Printf("Could not remove %s from %s: %s", entry.Marshal(), jobKey, err)
+		return err
+	}
+	if removed == 0 {
+		log.Printf("WARNING: Could not find item %s to remove from queue %s", entry.Marshal(), jobKey)
+		return errors.New("could not find item to remove from queue")
+	}
+	return nil
+}
+
+func AddToQueue(client redis.Cmdable, queueName QueueName, entry JobQueueEntry) error {
+	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
+	_, err := client.RPush(jobKey, entry.Marshal()).Result()
+	return err
+}
+
+/** -----------------
+locking functions
+----------------
+*/
+
+/**
+check if the given queue lock is set
+*/
+func CheckQueueLock(client *redis.Client, queueName QueueName) (bool, error) {
+	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
+
+	result, err := client.Exists(jobKey).Result()
+	if err != nil {
+		log.Printf("Could not check lock for %s: %s", jobKey, err)
+		return true, err
+	}
+	if result > 0 {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+/**
+set the given queue lock
+*/
+func SetQueueLock(client *redis.Client, queueName QueueName) {
+	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
+
+	client.Set(jobKey, "set", 2*time.Second)
+}
+
+/**
+release the given queue lock
+*/
+func ReleaseQueueLock(client *redis.Client, queueName QueueName) {
+	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
+	client.Del(jobKey)
+}
+
+/*
+block until the given queue lock is available or the timeout occurs
+*/
+func WaitForQueueLock(client *redis.Client, queueName QueueName, timeout time.Duration) error {
+	timeoutTimer := time.NewTicker(timeout)
+	clearedChannel := make(chan error)
+
+	go func() {
+		for {
+			locked, checkErr := CheckQueueLock(client, queueName)
+			if checkErr != nil {
+				clearedChannel <- checkErr
+			} else {
+				if locked {
+					time.Sleep(50 * time.Millisecond)
+				} else {
+					clearedChannel <- nil
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-timeoutTimer.C:
+		return errors.New(fmt.Sprintf("Timed out waiting for lock on %s", queueName))
+	case checkErr := <-clearedChannel:
+		return checkErr
+	}
+}
+
+type QueueLockCallback func(error)
+
+/*
+call the given callback (in a subthread) as soon as the queue becomes unlocked.
+optionally, assert the queue lock by calling SetQueueLock/ReleaseQueueLock either side of the callback
+remember that the callback is in a background goroutine, concurrency warnings apply
+*/
+func WhenQueueAvailable(client *redis.Client, queueName QueueName, callback QueueLockCallback, assertingQueue bool) {
+	intervalTicker := time.NewTicker(50 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-intervalTicker.C:
+				locked, checkErr := CheckQueueLock(client, queueName)
+				if checkErr != nil {
+					log.Printf("ERROR: Could not check lock for %s: %s", queueName, checkErr)
+					intervalTicker.Stop()
+					callback(checkErr)
+					return
+				}
+				if !locked {
+					intervalTicker.Stop()
+					if assertingQueue {
+						SetQueueLock(client, queueName)
+						defer ReleaseQueueLock(client, queueName)
+					}
+					callback(nil)
+					return
+				}
+			}
+		}
+	}()
+}

--- a/common/models/jobqueue_test.go
+++ b/common/models/jobqueue_test.go
@@ -10,6 +10,154 @@ import (
 	"time"
 )
 
+func TestJobQueueEntry_Marshal(t *testing.T) {
+	newEntry := JobQueueEntry{
+		JobId:  uuid.MustParse("814d602e-fbc0-488d-9aa5-0e11556ff846"),
+		StepId: uuid.MustParse("987aaeb3-1b5d-4215-a0e3-e3b56017b530"),
+		Status: 2,
+	}
+	result := newEntry.Marshal()
+	if result != "814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2" {
+		t.Errorf("JobQueueEntry.marshal returned wrong data, expected 814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2 got %s", result)
+	}
+}
+
+func TestUnmarshalJobQueueEntry(t *testing.T) {
+	rawData := "814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2"
+	result, err := UnmarshalJobQueueEntry(rawData)
+	if err != nil {
+		t.Error("UnmarshalJobQueueEntry failed unexpectedly: ", err)
+	} else {
+		if result.JobId != uuid.MustParse("814d602e-fbc0-488d-9aa5-0e11556ff846") {
+			t.Errorf("got incorrect job ID, expected 814d602e-fbc0-488d-9aa5-0e11556ff846 got %s", result.JobId)
+		}
+		if result.StepId != uuid.MustParse("987aaeb3-1b5d-4215-a0e3-e3b56017b530") {
+			t.Errorf("got incorrect step id, expected 987aaeb3-1b5d-4215-a0e3-e3b56017b530 got %s", result.StepId)
+		}
+		if result.Status != 2 {
+			t.Errorf("got incorrect status, expected 2 got %d", result.Status)
+		}
+	}
+
+	//UnmarshalJobQueueEntry should error if there are the wrong number of sections
+	wrongData1 := "814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2|3|4"
+	_, shouldErr1 := UnmarshalJobQueueEntry(wrongData1)
+	if shouldErr1 == nil {
+		t.Errorf("UnmarshalJobQu")
+	}
+}
+
+func TestGetQueueLength(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer s.Close()
+
+	testClient := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+
+	testClient.RPush("mediaflipper:jobrunningqueue", "a", "b", "c", "d", "e", "f", "g")
+	result, _ := GetQueueLength(testClient, RUNNING_QUEUE)
+	if result != 7 {
+		t.Errorf("Got incorrect queue length, expected 7 got %d", result)
+	}
+}
+
+func TestSnapshotQueue(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer s.Close()
+
+	testClient := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+
+	testData := []JobQueueEntry{
+		{uuid.UUID{}, uuid.UUID{}, 0},
+		{uuid.UUID{}, uuid.UUID{}, 1},
+		{uuid.UUID{}, uuid.UUID{}, 2},
+		{uuid.UUID{}, uuid.UUID{}, 3},
+	}
+	encodedData := make([]string, len(testData))
+	for i, d := range testData {
+		encodedData[i] = d.Marshal()
+	}
+	testClient.RPush("mediaflipper:jobrunningqueue", encodedData[0], encodedData[1], encodedData[2], encodedData[3])
+
+	result, snapErr := SnapshotQueue(testClient, RUNNING_QUEUE)
+	if snapErr != nil {
+		t.Error("SnapshotQueue unexpectedly failed: ", snapErr)
+	} else {
+		if len(result) != 4 {
+			t.Errorf("Expected 4 items in the queue, got %d", len(result))
+		} else {
+			if result[0].Status != JobStatus(0) {
+				t.Errorf("first entry had wrong status, expected 0 got %d", result[0].Status)
+			}
+			if result[1].Status != JobStatus(1) {
+				t.Errorf("first entry had wrong status, expected 1 got %d", result[1].Status)
+			}
+			if result[2].Status != JobStatus(2) {
+				t.Errorf("first entry had wrong status, expected 2 got %d", result[2].Status)
+			}
+			if result[3].Status != JobStatus(3) {
+				t.Errorf("first entry had wrong status, expected 3 got %d", result[3].Status)
+			}
+		}
+	}
+}
+
+func TestRemoveFromQueue(t *testing.T) {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer s.Close()
+
+	testClient := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+
+	testData := []JobQueueEntry{
+		{uuid.UUID{}, uuid.UUID{}, 0},
+		{uuid.UUID{}, uuid.UUID{}, 1},
+		{uuid.UUID{}, uuid.UUID{}, 2},
+		{uuid.UUID{}, uuid.UUID{}, 3},
+	}
+	encodedData := make([]string, len(testData))
+	for i, d := range testData {
+		encodedData[i] = d.Marshal()
+	}
+	testClient.RPush("mediaflipper:jobrunningqueue", encodedData[0], encodedData[1], encodedData[2], encodedData[3])
+
+	remErr := RemoveFromQueue(testClient, RUNNING_QUEUE, testData[2])
+	if remErr != nil {
+		t.Error("RemoveFromQueue unexpectedly failed: ", remErr)
+	} else {
+		result, snapErr := SnapshotQueue(testClient, RUNNING_QUEUE)
+		if snapErr != nil {
+			t.Error("SnapshotQueue unexpectedly failed: ", snapErr)
+		} else {
+			if len(result) != 3 {
+				t.Errorf("Expected 3 items in the queue after deletion, got %d", len(result))
+			} else {
+				if result[0].Status != JobStatus(0) {
+					t.Errorf("first entry had wrong status, expected 0 got %d", result[0].Status)
+				}
+				if result[1].Status != JobStatus(1) {
+					t.Errorf("first entry had wrong status, expected 1 got %d", result[1].Status)
+				}
+				if result[2].Status != JobStatus(3) {
+					t.Errorf("first entry had wrong status, expected 3 got %d", result[2].Status)
+				}
+			}
+		}
+	}
+}
 func TestAddToQueue(t *testing.T) {
 	s, err := miniredis.Run()
 	if err != nil {

--- a/common/models/jobqueue_test.go
+++ b/common/models/jobqueue_test.go
@@ -1,22 +1,16 @@
-package jobrunner
+package models
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/alicebob/miniredis"
 	"github.com/go-redis/redis/v7"
 	"github.com/google/uuid"
-	models2 "github.com/guardian/mediaflipper/common/models"
 	"log"
-	"reflect"
 	"testing"
 	"time"
 )
 
-/**
-CopyRunningQueueContent should return a snapshot of the running queue as a list of models.JobStep objects
-*/
-func TestCopyRunningQueueContent(t *testing.T) {
+func TestAddToQueue(t *testing.T) {
 	s, err := miniredis.Run()
 	if err != nil {
 		panic(err)
@@ -27,58 +21,29 @@ func TestCopyRunningQueueContent(t *testing.T) {
 		Addr: s.Addr(),
 	})
 
-	jobStepId := uuid.New()
-	testStep1 := models2.JobStepAnalysis{
-		JobStepType:            "analysis",
-		JobStepId:              jobStepId,
-		JobContainerId:         uuid.New(),
-		ContainerData:          nil,
-		StatusValue:            models2.JOB_STARTED,
-		ResultId:               uuid.New(),
-		MediaFile:              "path/to/something",
-		KubernetesTemplateFile: "mytemplate.yaml",
+	dbKey := fmt.Sprintf("mediaflipper:%s", RUNNING_QUEUE)
+
+	newEntry := JobQueueEntry{
+		JobId:  uuid.MustParse("814d602e-fbc0-488d-9aa5-0e11556ff846"),
+		StepId: uuid.MustParse("987aaeb3-1b5d-4215-a0e3-e3b56017b530"),
+		Status: 2,
 	}
 
-	testStep1Enc, _ := json.Marshal(testStep1)
-	testStep2 := models2.JobStepThumbnail{
-		JobStepType: "thumbnail",
-	}
-	testStep2Enc, _ := json.Marshal(testStep2)
-
-	keyName := fmt.Sprintf("mediaflipper:%s", RUNNING_QUEUE)
-	s.Lpush(keyName, string(testStep2Enc))
-	s.Lpush(keyName, string(testStep1Enc))
-
-	result, err := copyQueueContent(testClient, RUNNING_QUEUE)
-	if err != nil {
-		t.Error("copyQueueContent unexpectedly failed: ", err)
-		t.FailNow()
-	}
-
-	if len(*result) != 2 {
-		t.Errorf("expected 2 items from queue, got %d", len(*result))
-		t.FailNow()
-	}
-	decoded := make([]models2.JobStep, len(*result))
-	for i, jsonBlob := range *result {
-		var rawData map[string]interface{}
-		json.Unmarshal([]byte(jsonBlob), &rawData)
-		//spew.Dump(rawData)
-		var getErr error
-		decoded[i], getErr = getJobFromMap(rawData)
-		if getErr != nil {
-			t.Error("getJobFromMap unexpectedly failed: ", getErr)
+	addErr := AddToQueue(testClient, RUNNING_QUEUE, newEntry)
+	if addErr != nil {
+		t.Error("AddToQueue failed unexpectedly: ", addErr)
+	} else {
+		content, _ := testClient.LRange(dbKey, 0, 999).Result()
+		if len(content) < 1 {
+			t.Error("no data returned when content should have been stored")
+		} else {
+			if content[0] != "814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2" {
+				t.Errorf("returned content incorrect. Expected 814d602e-fbc0-488d-9aa5-0e11556ff846|987aaeb3-1b5d-4215-a0e3-e3b56017b530|2, got '%s'", content[0])
+			}
 		}
-	}
-
-	_, isAnalysis := decoded[0].(*models2.JobStepAnalysis)
-	if !isAnalysis {
-		t.Error("Step 0 was not analysis, got ", reflect.TypeOf(decoded[0]))
-	}
-
-	_, isThumb := decoded[1].(*models2.JobStepThumbnail)
-	if !isThumb {
-		t.Error("Step 1 was not thumbnail, got ", reflect.TypeOf(decoded[0]))
+		if len(content) != 1 {
+			t.Errorf("got extra items, expected 1 got %d", len(content))
+		}
 	}
 }
 

--- a/example_deployment/webapp_deployment.yaml
+++ b/example_deployment/webapp_deployment.yaml
@@ -19,8 +19,8 @@ spec:
         stack: MediaFlipper
     spec:
       containers:
-        - image: guardianmultimedia/mediaflipper:16
-#          imagePullPolicy: Always
+        - image: guardianmultimedia/mediaflipper:41
+          #imagePullPolicy: Always
           name: webapp-mediaflipper
           resources:
             requests:

--- a/example_deployment/webapp_deployment.yaml
+++ b/example_deployment/webapp_deployment.yaml
@@ -19,8 +19,8 @@ spec:
         stack: MediaFlipper
     spec:
       containers:
-        - image: guardianmultimedia/mediaflipper:41
-          #imagePullPolicy: Always
+        - image: guardianmultimedia/mediaflipper:DEV
+          imagePullPolicy: Always
           name: webapp-mediaflipper
           resources:
             requests:

--- a/webapp/analysis/receiveanalysisdata.go
+++ b/webapp/analysis/receiveanalysisdata.go
@@ -5,7 +5,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/guardian/mediaflipper/common/helpers"
 	models2 "github.com/guardian/mediaflipper/common/models"
-	"github.com/guardian/mediaflipper/webapp/jobrunner"
 	"log"
 	"net/http"
 	"reflect"
@@ -128,7 +127,7 @@ func (h ReceiveData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		completionChan <- newRecord
 	}
 
-	jobrunner.WhenQueueAvailable(h.redisClient, jobrunner.RUNNING_QUEUE, whenQueueReady, true)
+	models2.WhenQueueAvailable(h.redisClient, models2.RUNNING_QUEUE, whenQueueReady, true)
 	//we need to wait for completion or error, otherwise something below us writes out an empty response before the async function can
 	select {
 	case <-completionChan:

--- a/webapp/jobrunner/jobrunner.go
+++ b/webapp/jobrunner/jobrunner.go
@@ -24,7 +24,7 @@ type JobRunner struct {
 /**
 create a new JobRunner object
 */
-func NewJobRunner(redisClient *redis.Client, k8client *kubernetes.Clientset, templateManager *models2.JobTemplateManager, channelBuffer int, maxJobs int32) JobRunner {
+func NewJobRunner(redisClient *redis.Client, k8client *kubernetes.Clientset, templateManager *models2.JobTemplateManager, channelBuffer int, maxJobs int32, runProcessor bool) JobRunner {
 	shutdownChan := make(chan bool)
 	queuePollTicker := time.NewTicker(1 * time.Second)
 
@@ -36,7 +36,9 @@ func NewJobRunner(redisClient *redis.Client, k8client *kubernetes.Clientset, tem
 		templateMgr:     templateManager,
 		maxJobs:         maxJobs,
 	}
-	go runner.requestProcessor()
+	if runProcessor {
+		go runner.requestProcessor()
+	}
 	return runner
 }
 

--- a/webapp/jobrunner/jobrunner_test.go
+++ b/webapp/jobrunner/jobrunner_test.go
@@ -1,0 +1,22 @@
+package jobrunner
+
+import (
+	"testing"
+)
+
+func TestJobRunner_clearCompletedTick(t *testing.T) {
+	//still trying to work out exactly how to do this!!!!
+
+	//s, err := miniredis.Run()
+	//if err != nil {
+	//	panic(err)
+	//}
+	//defer s.Close()
+	//
+	//testClient := redis.NewClient(&redis.Options{
+	//	Addr: s.Addr(),
+	//})
+	//
+	//runner := JobRunner{redisClient:testClient,k8client: nil, shutdownChan:nil, queuePollTicker:nil,templateMgr:nil,maxJobs:10}
+
+}

--- a/webapp/jobrunner/jobrunnerrequestDAO.go
+++ b/webapp/jobrunner/jobrunnerrequestDAO.go
@@ -2,31 +2,17 @@ package jobrunner
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/go-redis/redis/v7"
-	"github.com/google/uuid"
-	models2 "github.com/guardian/mediaflipper/common/models"
+	"github.com/guardian/mediaflipper/common/models"
 	"log"
-	"time"
 )
 
-type QueueName string
-
-const (
-	REQUEST_QUEUE QueueName = "jobrequestqueue"
-	RUNNING_QUEUE QueueName = "jobrunningqueue"
-)
-
-func keyForJobId(id uuid.UUID) string {
-	return fmt.Sprintf("mediaflipper:jobrequest:%s", id.String())
+func getNextRequestQueueEntry(client *redis.Client) (*models.JobContainer, error) {
+	return getNextJobRunnerRequest(client, models.REQUEST_QUEUE)
 }
 
-func getNextRequestQueueEntry(client *redis.Client) (*models2.JobContainer, error) {
-	return getNextJobRunnerRequest(client, REQUEST_QUEUE)
-}
-
-func getNextJobRunnerRequest(client *redis.Client, queueName QueueName) (*models2.JobContainer, error) {
+func getNextJobRunnerRequest(client *redis.Client, queueName models.QueueName) (*models.JobContainer, error) {
 	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
 
 	result := client.LPop(jobKey)
@@ -44,7 +30,7 @@ func getNextJobRunnerRequest(client *redis.Client, queueName QueueName) (*models
 		log.Print("DEBUG: no items in queue right now")
 		return nil, nil
 	}
-	var rq models2.JobContainer
+	var rq models.JobContainer
 	log.Printf("DEBUG: Got %s for %s", content, jobKey)
 
 	marshalErr := json.Unmarshal([]byte(content), &rq)
@@ -56,27 +42,17 @@ func getNextJobRunnerRequest(client *redis.Client, queueName QueueName) (*models
 	return &rq, nil
 }
 
-func pushToRequestQueue(client *redis.Client, item *models2.JobContainer) error {
+func pushToRequestQueue(client *redis.Client, item *models.JobContainer) error {
 	encodedContent, marshalErr := json.Marshal(*item)
 	if marshalErr != nil {
 		log.Print("Could not encode content for ", item, ": ", marshalErr)
 		return marshalErr
 	}
 
-	return pushToQueue(client, encodedContent, REQUEST_QUEUE)
+	return pushToQueue(client, encodedContent, models.REQUEST_QUEUE)
 }
 
-func pushToRunningQueue(client *redis.Client, item *models2.JobStep) error {
-	encodedContent, marshalErr := json.Marshal(*item)
-	if marshalErr != nil {
-		log.Print("Could not encode content for ", item, ": ", marshalErr)
-		return marshalErr
-	}
-
-	return pushToQueue(client, encodedContent, RUNNING_QUEUE)
-}
-
-func pushToQueue(client *redis.Client, encodedContent []byte, queueName QueueName) error {
+func pushToQueue(client *redis.Client, encodedContent []byte, queueName models.QueueName) error {
 	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
 
 	//log.Printf("DEBUG: Pushed %s to %s", string(encodedContent), jobKey)
@@ -90,86 +66,11 @@ func pushToQueue(client *redis.Client, encodedContent []byte, queueName QueueNam
 	return nil
 }
 
-func getRequestQueueLength(client *redis.Client) (int64, error) {
-	return getQueueLength(client, REQUEST_QUEUE)
-}
-
-func getRunningQueueLength(client *redis.Client) (int64, error) {
-	return getQueueLength(client, RUNNING_QUEUE)
-}
-
-func getQueueLength(client *redis.Client, queueName QueueName) (int64, error) {
-	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
-	result := client.LLen(jobKey)
-
-	count, err := result.Result()
-	if err != nil {
-		log.Printf("Could not retrieve queue length for %s: %s", queueName, err)
-	}
-	return count, err
-}
-
-func getJobFromMap(fromMap map[string]interface{}) (models2.JobStep, error) {
-	jobType, isStr := fromMap["stepType"].(string)
-	if !isStr {
-		log.Printf("Could not determine job type, stepType parameter missing or wrong format")
-		return nil, errors.New("Could not determine job type")
-	}
-	switch jobType {
-	case "analysis":
-		aJobPtr, anErr := models2.JobStepAnalysisFromMap(fromMap)
-		if anErr == nil {
-			log.Printf("Got JobStepAnalysis")
-			return aJobPtr, nil
-		}
-	case "thumbnail":
-		tJobPtr, tErr := models2.JobStepThumbnailFromMap(fromMap)
-		if tErr == nil && tJobPtr.JobStepType == "thumbnail" {
-			log.Printf("Got JobStepThumbnail")
-			return tJobPtr, nil
-		}
-	case "transcode":
-		tJobPtr, tErr := models2.JobStepTranscodeFromMap(fromMap)
-		if tErr == nil && tJobPtr.JobStepType == "transcode" {
-			log.Printf("Got JobStepTranscode")
-			return tJobPtr, nil
-		}
-	}
-	return nil, errors.New(fmt.Sprintf("Could not decode to any known job type, got %s", fromMap["stepType"]))
-}
-
-func copyRunningQueueContent(client *redis.Client) (*[]models2.JobStep, error) {
-	result, getErr := copyQueueContent(client, RUNNING_QUEUE)
-	if getErr != nil {
-		return nil, getErr
-	}
-
-	rtn := make([]models2.JobStep, len(*result))
-	for i, resultString := range *result {
-		var rq map[string]interface{}
-		log.Printf("content before unmarshal: %s", resultString)
-		unmarshalEr := json.Unmarshal([]byte(resultString), &rq)
-		if unmarshalEr != nil {
-			log.Print("ERROR: Corrupted information in ", RUNNING_QUEUE, " queue: ", unmarshalEr)
-			return nil, unmarshalEr
-		}
-
-		step, stepErr := getJobFromMap(rq)
-		if stepErr != nil {
-			log.Print("ERROR: Corrupted information in ", RUNNING_QUEUE, " queue: ", stepErr)
-			return nil, stepErr
-		}
-		rtn[i] = step
-	}
-
-	return &rtn, nil
-}
-
 /**
 download a snapshot of the current queue. it's a good idea to assert the queue lock before taking the snapshot
 and release it when the processing is done, so that the queue content remains valid.
 */
-func copyQueueContent(client *redis.Client, queueName QueueName) (*[]string, error) {
+func copyQueueContent(client redis.Cmdable, queueName models.QueueName) ([]string, error) {
 	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
 
 	cmd := client.LRange(jobKey, 0, -1)
@@ -179,123 +80,5 @@ func copyQueueContent(client *redis.Client, queueName QueueName) (*[]string, err
 		log.Printf("Could not range %s: %s", jobKey, err)
 		return nil, err
 	}
-	return &result, nil
-}
-
-/**
-remove the given item from the given queue.
-*/
-func removeFromQueue(client *redis.Client, queueName QueueName, entry *models2.JobStep) error {
-	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
-	content, _ := json.Marshal(entry)
-	//log.Printf("Removing item %s from queue %s", string(content), jobKey)
-
-	result, err := client.LRem(jobKey, 0, string(content)).Result()
-	if err != nil {
-		log.Printf("Could not remove element from queue %s: %s", queueName, err)
-		return err
-	}
-	if result == 0 {
-		log.Printf("ERROR: Could not remove item %s from queue %s, not found", string(content), jobKey)
-	}
-	return nil
-}
-
-/**
-check if the given queue lock is set
-*/
-func CheckQueueLock(client *redis.Client, queueName QueueName) (bool, error) {
-	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
-
-	result, err := client.Exists(jobKey).Result()
-	if err != nil {
-		log.Printf("Could not check lock for %s: %s", jobKey, err)
-		return true, err
-	}
-	if result > 0 {
-		return true, nil
-	} else {
-		return false, nil
-	}
-}
-
-/**
-set the given queue lock
-*/
-func SetQueueLock(client *redis.Client, queueName QueueName) {
-	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
-
-	client.Set(jobKey, "set", 2*time.Second)
-}
-
-/**
-release the given queue lock
-*/
-func ReleaseQueueLock(client *redis.Client, queueName QueueName) {
-	jobKey := fmt.Sprintf("mediaflipper:%s:lock", queueName)
-	client.Del(jobKey)
-}
-
-/*
-block until the given queue lock is available or the timeout occurs
-*/
-func WaitForQueueLock(client *redis.Client, queueName QueueName, timeout time.Duration) error {
-	timeoutTimer := time.NewTicker(timeout)
-	clearedChannel := make(chan error)
-
-	go func() {
-		for {
-			locked, checkErr := CheckQueueLock(client, queueName)
-			if checkErr != nil {
-				clearedChannel <- checkErr
-			} else {
-				if locked {
-					time.Sleep(50 * time.Millisecond)
-				} else {
-					clearedChannel <- nil
-				}
-			}
-		}
-	}()
-
-	select {
-	case <-timeoutTimer.C:
-		return errors.New(fmt.Sprintf("Timed out waiting for lock on %s", queueName))
-	case checkErr := <-clearedChannel:
-		return checkErr
-	}
-}
-
-type QueueLockCallback func(error)
-
-/*
-call the given callback (in a subthread) as soon as the queue becomes unlocked.
-optionally, assert the queue lock by calling SetQueueLock/ReleaseQueueLock either side of the callback
-remember that the callback is in a background goroutine, concurrency warnings apply
-*/
-func WhenQueueAvailable(client *redis.Client, queueName QueueName, callback QueueLockCallback, assertingQueue bool) {
-	intervalTicker := time.NewTicker(50 * time.Millisecond)
-	go func() {
-		for {
-			select {
-			case <-intervalTicker.C:
-				locked, checkErr := CheckQueueLock(client, queueName)
-				if checkErr != nil {
-					log.Printf("ERROR: Could not check lock for %s: %s", queueName, checkErr)
-					intervalTicker.Stop()
-					callback(checkErr)
-					return
-				}
-				if !locked {
-					intervalTicker.Stop()
-					if assertingQueue {
-						SetQueueLock(client, queueName)
-						defer ReleaseQueueLock(client, queueName)
-					}
-					callback(nil)
-					return
-				}
-			}
-		}
-	}()
+	return result, nil
 }

--- a/webapp/jobrunner/jobrunnerrequestDAO.go
+++ b/webapp/jobrunner/jobrunnerrequestDAO.go
@@ -49,36 +49,12 @@ func pushToRequestQueue(client *redis.Client, item *models.JobContainer) error {
 		return marshalErr
 	}
 
-	return pushToQueue(client, encodedContent, models.REQUEST_QUEUE)
-}
-
-func pushToQueue(client *redis.Client, encodedContent []byte, queueName models.QueueName) error {
-	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
-
-	//log.Printf("DEBUG: Pushed %s to %s", string(encodedContent), jobKey)
+	jobKey := fmt.Sprintf("mediaflipper:%s", models.REQUEST_QUEUE)
 
 	result := client.RPush(jobKey, string(encodedContent))
 	if result.Err() != nil {
 		log.Printf("Could not push to list %s: %s", jobKey, result.Err())
 		return result.Err()
 	}
-	//log.Printf("DEBUG: pushed %s to %s", item.RequestId, queueName)
 	return nil
-}
-
-/**
-download a snapshot of the current queue. it's a good idea to assert the queue lock before taking the snapshot
-and release it when the processing is done, so that the queue content remains valid.
-*/
-func copyQueueContent(client redis.Cmdable, queueName models.QueueName) ([]string, error) {
-	jobKey := fmt.Sprintf("mediaflipper:%s", queueName)
-
-	cmd := client.LRange(jobKey, 0, -1)
-	result, err := cmd.Result()
-
-	if err != nil {
-		log.Printf("Could not range %s: %s", jobKey, err)
-		return nil, err
-	}
-	return result, nil
 }

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -73,6 +73,7 @@ func main() {
 	var app MyHttpApp
 
 	kubeConfigPath := flag.String("kubeconfig", "", ".kubeconfig file for running out of cluster. If not specified then in-cluster initialisation will be tried")
+	noProcessor := flag.Bool("noprocessor", false, "set this option to disable background processing of jobs.")
 	flag.Parse()
 
 	/*
@@ -105,7 +106,7 @@ func main() {
 		log.Printf("Could not initialise template manager: %s", mgrLoadErr)
 	}
 
-	runner := jobrunner.NewJobRunner(redisClient, k8Client, templateMgr, 10, 2)
+	runner := jobrunner.NewJobRunner(redisClient, k8Client, templateMgr, 10, 10, !(*noProcessor))
 
 	app.index.filePath = "static/index.html"
 	app.index.contentType = "text/html"

--- a/webapp/thumbnail/receivedata.go
+++ b/webapp/thumbnail/receivedata.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-redis/redis/v7"
 	"github.com/guardian/mediaflipper/common/helpers"
 	models2 "github.com/guardian/mediaflipper/common/models"
-	"github.com/guardian/mediaflipper/webapp/jobrunner"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -137,6 +136,6 @@ func (h ReceiveData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		completionChan <- true
 	}
 
-	jobrunner.WhenQueueAvailable(h.redisClient, jobrunner.RUNNING_QUEUE, whenQueueReady, true)
+	models2.WhenQueueAvailable(h.redisClient, models2.RUNNING_QUEUE, whenQueueReady, true)
 	<-completionChan
 }

--- a/webapp/transcode/receivedata.go
+++ b/webapp/transcode/receivedata.go
@@ -7,7 +7,6 @@ import (
 	"github.com/guardian/mediaflipper/common/helpers"
 	models2 "github.com/guardian/mediaflipper/common/models"
 	"github.com/guardian/mediaflipper/common/results"
-	"github.com/guardian/mediaflipper/webapp/jobrunner"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -130,6 +129,6 @@ func (h ReceiveData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		completionChan <- true
 	}
 
-	jobrunner.WhenQueueAvailable(h.redisClient, jobrunner.RUNNING_QUEUE, whenQueueReady, true)
+	models2.WhenQueueAvailable(h.redisClient, models2.RUNNING_QUEUE, whenQueueReady, true)
 	<-completionChan
 }


### PR DESCRIPTION
Keeping full job step data on the running queue was leading to in-sync problems as the jobs are updated by the http handlers responding to data being sent from the wrapper process.  This could lead to a job becoming "orphaned" on the queue and repeated attempts to complete or fail it ultimately resulting in an IndexError and server crash which manifested as a 502 in the user interface.

The running queue has been reworked to keep only the IDs required and full objects are lifted from the store as needed.  The waiting queue is kept as-is for the time being owing to time constraints.