### PR TITLE
Add a pix_fmt option

### DIFF
--- a/common/helpers/config.go
+++ b/common/helpers/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Redis        RedisConfig    `yaml:"redis"`
 	Scratch      ScratchStorage `yaml:"scratch"`
 	SettingsPath string         `yaml:"settingspath"`
+	MaxJobs      int            `yaml:"maxjobs"`
 }
 
 func ReadConfig(configFile string) (*Config, error) {

--- a/common/models/transcodesettings.go
+++ b/common/models/transcodesettings.go
@@ -31,6 +31,7 @@ type VideoSettings struct {
 	CRF     int8           `json:"crf" yaml:"crf"`         //A lower value generally leads to higher quality, and a subjectively sane range is 17–28. Consider 17 or 18 to be visually lossless or nearly so
 	Preset  string         `json:"preset" yaml:"preset"`   //see https://trac.ffmpeg.org/wiki/Encode/H.264
 	Scale   *ScaleSettings `json:"scale" yaml:"scale"`
+	PixFmt  string         `json:"pix_fmt" yaml:"pix_fmt"`
 }
 
 type AudioSettings struct {
@@ -79,7 +80,6 @@ func (v VideoSettings) MarshalToArray() []string {
 	out := []string{
 		"-vcodec",
 		v.Codec,
-		//"-pix_fmt yuv420p",
 	}
 	if v.CRF > 0 {
 		if v.CRF < 17 || v.CRF > 28 {
@@ -94,6 +94,9 @@ func (v VideoSettings) MarshalToArray() []string {
 	}
 	if v.Scale != nil {
 		out = append(out, "-vf", v.Scale.MarshalToString())
+	}
+	if v.PixFmt != "" {
+		out = append(out, "-pix_fmt", v.PixFmt)
 	}
 	return out
 }

--- a/common/models/transcodesettings.go
+++ b/common/models/transcodesettings.go
@@ -31,7 +31,7 @@ type VideoSettings struct {
 	CRF     int8           `json:"crf" yaml:"crf"`         //A lower value generally leads to higher quality, and a subjectively sane range is 17–28. Consider 17 or 18 to be visually lossless or nearly so
 	Preset  string         `json:"preset" yaml:"preset"`   //see https://trac.ffmpeg.org/wiki/Encode/H.264
 	Scale   *ScaleSettings `json:"scale" yaml:"scale"`
-	PixFmt  string         `json:"pix_fmt" yaml:"pix_fmt"`
+	PixFmt  string         `json:"pixfmt" yaml:"pixfmt"`
 }
 
 type AudioSettings struct {

--- a/common/models/transcodesettings_test.go
+++ b/common/models/transcodesettings_test.go
@@ -25,6 +25,7 @@ func TestTranscodeSettingsLoad(t *testing.T) {
     samplerate: 48000
   video:
     codec: h264
+    pixfmt: yuv420p
     bitrate: 1048576  #1mbit/s
     scale:
       scalex: 1280
@@ -80,6 +81,9 @@ func TestTranscodeSettingsLoad(t *testing.T) {
 		if settings[0].Video.Scale.ScaleX != 1280 {
 			t.Errorf("Expected scale.scaleX to be 1280, got %d", settings[0].Video.Scale.ScaleX)
 		}
+		if settings[0].Video.PixFmt != "yuv420p" {
+			t.Errorf("Expected video.pix_fmt to be yuv420p, got %s", settings[0].Video.PixFmt)
+		}
 	}
 }
 
@@ -94,6 +98,7 @@ func TestTranscodeSettingsMarshal(t *testing.T) {
 			CRF:    19,
 			Preset: "fast",
 			Scale:  nil,
+			PixFmt: "yuv420p",
 		},
 		Audio:   AudioSettings{},
 		Wrapper: WrapperSettings{},
@@ -110,6 +115,9 @@ func TestTranscodeSettingsMarshal(t *testing.T) {
 		}
 		if !strings.Contains(strContent, "\"name\":\"avtest\"") {
 			t.Error("returned content did not contain the right name!")
+		}
+		if !strings.Contains(strContent, "\"pixfmt\":\"yuv420p\"") {
+			t.Error("returned content did not contain pix_fmt")
 		}
 	}
 }

--- a/docker/awsupload/do_upload.sh
+++ b/docker/awsupload/do_upload.sh
@@ -32,11 +32,28 @@ if [ "${STRIP_PATH_COUNT}" != "" ]; then
     echo Output path is now ${OUTPUT_PATH}
 fi
 
+FAILED=0
 echo Uploading \"${TRANSCODED_MEDIA}\" to \"${OUTPUT_PATH}\" on \"${OUTPUT_BUCKET}\"...
 aws s3 cp "${TRANSCODED_MEDIA}" "s3://${OUTPUT_BUCKET}/${OUTPUT_PATH}/`basename ${MEDIA_FILE}`"
+
+if [ "$?" == "" ]; then
+  FAILED=$?
+fi
 
 if [ "${THUMBNAIL_IMAGE}" != "" ]; then
   aws s3 cp "${THUMBNAIL_IMAGE}" "s3://${OUTPUT_BUCKET}/${OUTPUT_PATH}/`basename ${THUMBNAIL_IMAGE}`"
 fi
 
-exit $?
+if [ "$?" == "" ]; then
+  FAILED=$?
+fi
+
+if [ "$FAILED" == "0" ]; then
+  echo Removing local transcode copy...
+  rm -f "${TRANSCODED_MEDIA}"
+  if [ "${THUMBNAIL_IMAGE}" != "" ]; then
+    rm -f "${THUMBNAIL_IMAGE}"
+  fi
+fi
+
+exit $FAILED

--- a/reaper/Makefile
+++ b/reaper/Makefile
@@ -12,3 +12,4 @@ dev: $(GOFILES)
 
 clean:
 	rm -f reaper
+	find . -iname \*.out -delete

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -16,3 +16,4 @@ test: $(GOFILES)
 
 clean:
 	rm -f webapp
+	find . -iname \*.out -delete

--- a/webapp/config/settings/mp4proxy.yaml
+++ b/webapp/config/settings/mp4proxy.yaml
@@ -12,6 +12,8 @@
   video:
     codec: h264
     bitrate: 1048576  #1mbit/s
+    pixfmt: yuv420p
+    preset: fast
     scale:
       scalex: 1280
       scaley: -1

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -109,7 +109,12 @@ func main() {
 		log.Printf("Could not initialise template manager: %s", mgrLoadErr)
 	}
 
-	runner := jobrunner.NewJobRunner(redisClient, k8Client, templateMgr, 10, !(*noProcessor))
+	if config.MaxJobs == 0 {
+		config.MaxJobs = 10
+	}
+
+	log.Printf("INFO: MaxJobs is set to %d", config.MaxJobs)
+	runner := jobrunner.NewJobRunner(redisClient, k8Client, templateMgr, int32(config.MaxJobs), !(*noProcessor))
 
 	app.index.filePath = "static/index.html"
 	app.index.contentType = "text/html"

--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -13,3 +13,4 @@ dev: $(GOFILES)
 
 clean:
 	rm -f wrapper
+	find . -iname \*.out -delete

--- a/wrapper/main.go
+++ b/wrapper/main.go
@@ -187,6 +187,12 @@ func main() {
 
 		log.Print("Got thumbnail result: ", result)
 
+		if result != nil && result.OutPath != nil {
+			chmodErr := os.Chmod(*result.OutPath, 0777)
+			if chmodErr != nil {
+				log.Printf("ERROR: could not open permissions on %s: %s", *result.OutPath, chmodErr)
+			}
+		}
 		sendErr := SendToWebapp(sendUrl, result, 0, maxTries)
 		if sendErr != nil {
 			log.Fatalf("Could not send results to %s: %s", sendUrl, sendErr)
@@ -233,6 +239,13 @@ func main() {
 				OutFile:      "",
 				TimeTaken:    0,
 				ErrorMessage: "could not recognise settings as valid for a transcode operation. Maybe you meant thumbnail?",
+			}
+		}
+
+		if result.OutFile != "" {
+			chmodErr := os.Chmod(result.OutFile, 0777)
+			if chmodErr != nil {
+				log.Printf("ERROR: could not open permissions on %s: %s", result.OutFile, chmodErr)
 			}
 		}
 


### PR DESCRIPTION
10-bit media needs to be forced to 8-bit yuv 4:2:0 in order to play back properly in FFox, Quicktime, Safari etc.