### PR TITLE
Feature/rebuild proxy dirs

### DIFF
--- a/helper_app/rebuild_directory_tree/bulk_id_filter.go
+++ b/helper_app/rebuild_directory_tree/bulk_id_filter.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/google/uuid"
+	"github.com/guardian/mediaflipper/common/models"
+)
+
+func AsyncFilterBulkId(inputCh chan *models.JobContainer, bulkId *uuid.UUID, queueSize int) chan *models.JobContainer {
+	outputCh := make(chan *models.JobContainer, queueSize)
+
+	go func() {
+		for {
+			rec := <- inputCh
+			if rec==nil {
+				outputCh <- nil
+				return
+			}
+			if bulkId==nil {
+				outputCh <- rec
+			} else {
+				if rec.AssociatedBulk.List==*bulkId {
+					outputCh <- rec
+				}
+			}
+		}
+	}()
+	return outputCh
+}

--- a/helper_app/rebuild_directory_tree/copier.go
+++ b/helper_app/rebuild_directory_tree/copier.go
@@ -1,30 +1,112 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"log"
+	"math"
 	"os"
+	"path"
+	"sync"
 )
 
 func checkFileExists(filepath string) bool {
 	_, statErr := os.Stat(filepath)
-	if statErr==nil {
+	if statErr == nil {
 		return true
 	} else {
 		return !os.IsNotExist(statErr)
 	}
 }
 
-func AsyncCopier(inputCh chan *CopyRequest) chan error {
+func copyFile(from string, to string) (int64, error) {
+	sourceFile, sourceOpenErr := os.Open(from)
+	if sourceOpenErr != nil {
+		return 0, sourceOpenErr
+	}
+	defer sourceFile.Close()
+	destFile, destOpenErr := os.OpenFile(to, os.O_CREATE|os.O_WRONLY, 0640)
+	if destOpenErr != nil {
+		return 0, destOpenErr
+	}
+	defer destFile.Close()
+
+	return io.Copy(destFile, sourceFile)
+}
+
+func fileSizeFormatter(size int64) string {
+	suffices := []string{"bytes", "Kb", "Mb", "Gb"}
+
+	currentSize := float64(size)
+	for i, suffix := range suffices {
+		if currentSize < 1024 {
+			return fmt.Sprintf("%.1f%s", currentSize, suffix)
+		}
+		currentSize = float64(size) / math.Pow(1024, float64(i))
+	}
+	return fmt.Sprintf("%.1fGb", float64(size)/math.Pow(1024, 3))
+}
+
+func copierThread(inputCh chan *CopyRequest, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+	for {
+		rec := <-inputCh
+		if rec == nil {
+			log.Printf("INFO copierThread exiting")
+			return
+		}
+
+		if !checkFileExists(rec.From) {
+			log.Printf("ERROR copierThread %s does not exist to copy from", rec.From)
+			continue
+		}
+
+		if checkFileExists(rec.To) {
+			log.Printf("ERROR copierThread %s already exists, won't over-write", rec.To)
+			continue
+		}
+
+		mkDirErr := os.MkdirAll(path.Dir(rec.To), 0755)
+		if mkDirErr != nil {
+			log.Printf("ERROR copierThread can't create directory %s: %s", path.Dir(rec.To), mkDirErr)
+			continue
+		}
+
+		byteSize, copyErr := copyFile(rec.From, rec.To)
+		if copyErr != nil {
+			log.Printf("ERROR copierThread can't copy '%s' to '%s': %s", rec.From, rec.To, copyErr)
+			continue
+		} else {
+			log.Printf("INFO copierThread coped %s: %s", rec.To, fileSizeFormatter(byteSize))
+		}
+	}
+}
+
+func AsyncCopier(inputCh chan *CopyRequest, parallelCopies int) chan error {
 	errCh := make(chan error, 1)
+	modifiedInputCh := make(chan *CopyRequest, cap(inputCh))
+	waitGroup := &sync.WaitGroup{}
+
+	for i := 0; i < parallelCopies; i++ {
+		go copierThread(modifiedInputCh, waitGroup)
+		waitGroup.Add(1)
+	}
 
 	go func() {
 		for {
-			req := <- inputCh
-			if req==nil {
-				log.Print("INFO AsyncCopier reached end of stream, terminating")
+			req := <-inputCh
+			if req == nil {
+				log.Print("INFO AsyncCopier reached end of stream, signalling threads")
+				for i := 0; i < parallelCopies; i++ {
+					modifiedInputCh <- nil
+				}
+				log.Print("INFO AsyncCopier waiting...")
+				waitGroup.Wait()
+				log.Print("INFO AsyncCopier all threads exitied, shutting down")
 				errCh <- nil
 				return
 			}
+			modifiedInputCh <- req
 
 			log.Printf("DEBUG AsyncCopier request to copy %s to %s", req.From, req.To)
 		}

--- a/helper_app/rebuild_directory_tree/copier.go
+++ b/helper_app/rebuild_directory_tree/copier.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func checkFileExists(filepath string) bool {
+	_, statErr := os.Stat(filepath)
+	if statErr==nil {
+		return true
+	} else {
+		return !os.IsNotExist(statErr)
+	}
+}
+
+func AsyncCopier(inputCh chan *CopyRequest) chan error {
+	errCh := make(chan error, 1)
+
+	go func() {
+		for {
+			req := <- inputCh
+			if req==nil {
+				log.Print("INFO AsyncCopier reached end of stream, terminating")
+				errCh <- nil
+				return
+			}
+
+			log.Printf("DEBUG AsyncCopier request to copy %s to %s", req.From, req.To)
+		}
+	}()
+
+	return errCh
+}

--- a/helper_app/rebuild_directory_tree/copy_request_builder.go
+++ b/helper_app/rebuild_directory_tree/copy_request_builder.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/guardian/mediaflipper/common/models"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path"
+	"strings"
+)
+
+type CopyRequest struct {
+	From string
+	To string
+}
+
+type GenericResponseContainer struct {
+	Status string `json:"status"`
+	Count int `json:"count"`
+	Entries []models.FileEntry `json:"entries"`
+}
+
+func lookupAssociatedFiles(baseUrl string, jobId uuid.UUID) (*[]models.FileEntry, error) {
+	targetUrl := fmt.Sprintf("%s/api/file/byJob?jobId=%s", baseUrl, jobId.String())
+	response, err := http.Get(targetUrl)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	contentBytes, readErr := ioutil.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	var parsedContent GenericResponseContainer
+	unmarshalErr := json.Unmarshal(contentBytes, &parsedContent)
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
+	}
+
+	return &(parsedContent.Entries), nil
+}
+
+func makeDestPath(sourceMediaFile string, outputBasePath string, targetPathStrip int) (string, error) {
+	originalMediaPath := path.Dir(sourceMediaFile)
+	if strings.HasPrefix(originalMediaPath, "/") {
+		originalMediaPath = originalMediaPath[1:]
+	}
+	pathParts := strings.Split(originalMediaPath, "/")
+
+	var partsToUse []string
+	if len(pathParts)>= targetPathStrip {
+		partsToUse = pathParts[targetPathStrip:]
+	} else {
+		return "", errors.New(fmt.Sprintf("the incoming path '%s' does not have enough segments to strip %d away", originalMediaPath, targetPathStrip))
+	}
+
+	return path.Join(outputBasePath, strings.Join(partsToUse, "/")), nil
+}
+
+/**
+looks up the files associated with the incoming job and pushes CopyRequest objects onto the output channel
+for each file
+ */
+func AsyncCopyRequestBuilder(inputCh chan *models.JobContainer, baseUrl string, outputBasePath string, targetPathStrip int, queueSize int) (chan *CopyRequest, chan error) {
+	outputCh := make(chan *CopyRequest, queueSize)
+	errCh := make(chan error, 1)
+
+	go func() {
+		for {
+			rec := <- inputCh
+			if rec==nil {
+				log.Print("INFO AsyncCopyRequestBuilder reached end of stream")
+				outputCh <- nil
+				return
+			}
+
+			filesListPtr, getFilesErr := lookupAssociatedFiles(baseUrl, rec.Id)
+			if getFilesErr != nil {
+				log.Printf("WARNING AsyncCopyRequestBuilder could not get files for %s: %s", rec.Id, getFilesErr)
+				continue
+			}
+
+			desiredDestPath, destPathErr := makeDestPath(rec.IncomingMediaFile, outputBasePath, targetPathStrip)
+			if destPathErr != nil {
+				log.Printf("ERROR AsyncCopyRequestBuilder could not determine destination path: %s", destPathErr)
+				errCh <- destPathErr
+				return
+			}
+
+			for _, file := range *filesListPtr {
+				copyReq := &CopyRequest{
+					From: file.ServerPath,
+					To:   path.Join(desiredDestPath, path.Base(file.ServerPath)),
+				}
+				outputCh <- copyReq
+			}
+		}
+	}()
+
+	return outputCh, errCh
+}

--- a/helper_app/rebuild_directory_tree/main.go
+++ b/helper_app/rebuild_directory_tree/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"github.com/google/uuid"
+	"log"
+	"os"
+)
+
+/**
+this app reads the job history to determine the proxy and thumbnail for each record then copies the proxies to a
+new directory tree matching the original media.
+this is to make it easier to use the transcodes in ArchiveHunter and VaultDoor
+ */
+
+func checkOutputDirectory(dirpath string) bool {
+	statInfo, statErr := os.Stat(dirpath)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			log.Printf("ERROR the output path '%s' does not exist, can't continue", dirpath)
+			return false
+		}
+		log.Printf("ERROR can't check path '%s': %s", dirpath, statErr)
+		return false
+	}
+
+	if ! statInfo.IsDir() {
+		log.Printf("ERROR the output path '%s' is not a directory, can't continue", dirpath)
+		return false
+	}
+	return true
+}
+
+func main() {
+	limitToBulkIdPtr := flag.String("bulk","","if set, only copy items from the given bulk")
+	outputPath := flag.String("output","","path to output files to")
+	baseUrl := flag.String("url","http://localhost:9000", "location of the mediaflipper webapp")
+	pathStripCount := flag.Int("pathstrip", 2, "remove this many path segments from the original media path when calculating destination media path")
+	pageSize := flag.Int("pagesize",100,"how many items to grab at once")
+	flag.Parse()
+
+	if *outputPath == "" {
+		log.Fatal("You must specify an output path using '--output'")
+	}
+
+	if ! checkOutputDirectory(*outputPath) {
+		log.Fatal("Invalid output directory")
+	}
+
+	var limitToBulkId *uuid.UUID
+	if *limitToBulkIdPtr != "" {
+		uid, uidErr := uuid.Parse(*limitToBulkIdPtr)
+		if uidErr != nil {
+			log.Fatal("If you specify a value for -bulk it must be a valid UUID. Error was ", uidErr)
+		}
+		limitToBulkId = &uid
+	}
+
+	allJobsCh, jobScanErrCh := AsyncScanJobs(*baseUrl, *pageSize)
+	filteredJobsCh := AsyncFilterBulkId(allJobsCh, limitToBulkId, *pageSize)
+	copyReqCh, reqbuilderErrCh := AsyncCopyRequestBuilder(filteredJobsCh, *baseUrl, *outputPath, *pathStripCount, *pageSize)
+	copyErrCh := AsyncCopier(copyReqCh)
+
+	func() {
+		select {
+		case err := <- jobScanErrCh:
+			log.Print("ERROR main got error from job scanner: ", err)
+			return
+		case err := <- reqbuilderErrCh:
+			log.Print("ERROR main got error from request builder: ", err)
+			return
+		case err := <- copyErrCh:
+			if err==nil {
+				log.Print("INFO Completed")
+				return
+			}
+			log.Print("ERROR main got error from copier: ", err)
+			return
+		}
+	}()
+
+	log.Print("All done")
+}

--- a/helper_app/rebuild_directory_tree/main.go
+++ b/helper_app/rebuild_directory_tree/main.go
@@ -11,7 +11,7 @@ import (
 this app reads the job history to determine the proxy and thumbnail for each record then copies the proxies to a
 new directory tree matching the original media.
 this is to make it easier to use the transcodes in ArchiveHunter and VaultDoor
- */
+*/
 
 func checkOutputDirectory(dirpath string) bool {
 	statInfo, statErr := os.Stat(dirpath)
@@ -24,7 +24,7 @@ func checkOutputDirectory(dirpath string) bool {
 		return false
 	}
 
-	if ! statInfo.IsDir() {
+	if !statInfo.IsDir() {
 		log.Printf("ERROR the output path '%s' is not a directory, can't continue", dirpath)
 		return false
 	}
@@ -32,18 +32,19 @@ func checkOutputDirectory(dirpath string) bool {
 }
 
 func main() {
-	limitToBulkIdPtr := flag.String("bulk","","if set, only copy items from the given bulk")
-	outputPath := flag.String("output","","path to output files to")
-	baseUrl := flag.String("url","http://localhost:9000", "location of the mediaflipper webapp")
+	limitToBulkIdPtr := flag.String("bulk", "", "if set, only copy items from the given bulk")
+	outputPath := flag.String("output", "", "path to output files to")
+	baseUrl := flag.String("url", "http://localhost:9000", "location of the mediaflipper webapp")
 	pathStripCount := flag.Int("pathstrip", 2, "remove this many path segments from the original media path when calculating destination media path")
-	pageSize := flag.Int("pagesize",100,"how many items to grab at once")
+	pageSize := flag.Int("pagesize", 100, "how many items to grab at once")
+	parallelCopies := flag.Int("parallel", 4, "how many copies to perform in parallel")
 	flag.Parse()
 
 	if *outputPath == "" {
 		log.Fatal("You must specify an output path using '--output'")
 	}
 
-	if ! checkOutputDirectory(*outputPath) {
+	if !checkOutputDirectory(*outputPath) {
 		log.Fatal("Invalid output directory")
 	}
 
@@ -59,18 +60,18 @@ func main() {
 	allJobsCh, jobScanErrCh := AsyncScanJobs(*baseUrl, *pageSize)
 	filteredJobsCh := AsyncFilterBulkId(allJobsCh, limitToBulkId, *pageSize)
 	copyReqCh, reqbuilderErrCh := AsyncCopyRequestBuilder(filteredJobsCh, *baseUrl, *outputPath, *pathStripCount, *pageSize)
-	copyErrCh := AsyncCopier(copyReqCh)
+	copyErrCh := AsyncCopier(copyReqCh, *parallelCopies)
 
 	func() {
 		select {
-		case err := <- jobScanErrCh:
+		case err := <-jobScanErrCh:
 			log.Print("ERROR main got error from job scanner: ", err)
 			return
-		case err := <- reqbuilderErrCh:
+		case err := <-reqbuilderErrCh:
 			log.Print("ERROR main got error from request builder: ", err)
 			return
-		case err := <- copyErrCh:
-			if err==nil {
+		case err := <-copyErrCh:
+			if err == nil {
 				log.Print("INFO Completed")
 				return
 			}

--- a/helper_app/rebuild_directory_tree/scan_all_jobs.go
+++ b/helper_app/rebuild_directory_tree/scan_all_jobs.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/guardian/mediaflipper/common/models"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type ListJobResponse struct {
+	Status     string                  `json:"status"`
+	NextCursor uint64                  `json:"nextCursor"`
+	Entries    *[]models.JobContainer `json:"entries"`
+}
+
+func getNextPage(httpClient *http.Client, baseUrl string, startAt int, pageSize int) (*[]models.JobContainer, error){
+	targetUrl := fmt.Sprintf("%s/api/job?startindex=%d&limit=%d", baseUrl, startAt, startAt+pageSize)
+	response, err := httpClient.Get(targetUrl)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	bodyContent, readErr := ioutil.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	var parsedContent ListJobResponse
+	marshalErr := json.Unmarshal(bodyContent, &parsedContent)
+	if marshalErr!=nil {
+		return nil, marshalErr
+	}
+
+	return parsedContent.Entries, nil
+}
+
+func AsyncScanJobs(baseUrl string, pageSize int) (chan *models.JobContainer, chan error) {
+	outputCh := make(chan *models.JobContainer, pageSize)
+	errCh := make(chan error, 1)
+
+	go func(){
+		loaded := 0
+		httpClient := &http.Client{}
+		for {
+			results, loadErr := getNextPage(httpClient, baseUrl, loaded, pageSize)
+			if loadErr != nil {
+				log.Print("ERROR AsyncScanJobs could not read page: ", loadErr)
+				errCh <- loadErr
+				return
+			}
+			if results==nil {
+				log.Print("ERROR AsyncScanJobs received empty data")
+				errCh <- errors.New("no data returned")
+				return
+			}
+			if len(*results)==0 {
+				log.Print("INFO AsyncScanJobs completed scan")
+				outputCh <- nil
+				return
+			}
+
+			log.Printf("DEBUG AsyncScanJobs got page of %d results", len(*results))
+			for _, entry := range *results {
+				copiedEntry := entry
+				outputCh <- &copiedEntry
+			}
+		}
+	}()
+
+	return outputCh, errCh
+}

--- a/helper_app/rebuild_directory_tree/scan_all_jobs.go
+++ b/helper_app/rebuild_directory_tree/scan_all_jobs.go
@@ -11,12 +11,12 @@ import (
 )
 
 type ListJobResponse struct {
-	Status     string                  `json:"status"`
-	NextCursor uint64                  `json:"nextCursor"`
+	Status     string                 `json:"status"`
+	NextCursor uint64                 `json:"nextCursor"`
 	Entries    *[]models.JobContainer `json:"entries"`
 }
 
-func getNextPage(httpClient *http.Client, baseUrl string, startAt int, pageSize int) (*[]models.JobContainer, error){
+func getNextPage(httpClient *http.Client, baseUrl string, startAt int, pageSize int) (*[]models.JobContainer, error) {
 	targetUrl := fmt.Sprintf("%s/api/job?startindex=%d&limit=%d", baseUrl, startAt, startAt+pageSize)
 	response, err := httpClient.Get(targetUrl)
 	if err != nil {
@@ -31,7 +31,7 @@ func getNextPage(httpClient *http.Client, baseUrl string, startAt int, pageSize 
 
 	var parsedContent ListJobResponse
 	marshalErr := json.Unmarshal(bodyContent, &parsedContent)
-	if marshalErr!=nil {
+	if marshalErr != nil {
 		return nil, marshalErr
 	}
 
@@ -42,28 +42,29 @@ func AsyncScanJobs(baseUrl string, pageSize int) (chan *models.JobContainer, cha
 	outputCh := make(chan *models.JobContainer, pageSize)
 	errCh := make(chan error, 1)
 
-	go func(){
+	go func() {
 		loaded := 0
 		httpClient := &http.Client{}
 		for {
-			results, loadErr := getNextPage(httpClient, baseUrl, loaded, pageSize)
+			results, loadErr := getNextPage(httpClient, baseUrl, loaded, pageSize-1)
 			if loadErr != nil {
 				log.Print("ERROR AsyncScanJobs could not read page: ", loadErr)
 				errCh <- loadErr
 				return
 			}
-			if results==nil {
+			if results == nil {
 				log.Print("ERROR AsyncScanJobs received empty data")
 				errCh <- errors.New("no data returned")
 				return
 			}
-			if len(*results)==0 {
+			if len(*results) == 0 {
 				log.Print("INFO AsyncScanJobs completed scan")
 				outputCh <- nil
 				return
 			}
 
-			log.Printf("DEBUG AsyncScanJobs got page of %d results", len(*results))
+			loaded += len(*results)
+			log.Printf("DEBUG AsyncScanJobs got page of %d results for %d total", len(*results), loaded)
 			for _, entry := range *results {
 				copiedEntry := entry
 				outputCh <- &copiedEntry


### PR DESCRIPTION
## What does this change?
Adds a commandline helper tool which copies transcoded files from a flat file structure back into the directory structure corresponding to their original media.
This works by contacting the webapp server and analysing the job history, finding the transcoded versions for each original file and then forming a new path.  The files are then copied in parallel.

## How to test
Build the app and follow the instructions. `rebuild_directory_tree --help`

## How can we measure success?
Able to rebuild the directory structure in a parallel location for upload of proxies to archviehunter.  Automatic linkup of proxies to media in AH.

